### PR TITLE
Add hacks/@wealth-stress-count

### DIFF
--- a/characters/FateCore/character.dtd
+++ b/characters/FateCore/character.dtd
@@ -88,6 +88,7 @@
     <!ATTLIST hacks skill-modes         (true|false)     "false"> <!-- Fate System Toolkit     -->
     <!ATTLIST hacks stress-base-count   CDATA #IMPLIED>
     <!ATTLIST hacks systems-stress      (true|false)     "false"> <!-- Mostly for Mindjammer   -->
+    <!ATTLIST hacks wealth-stress-count CDATA #IMPLIED>           <!-- Fate System Toolkit     -->
 
   <!ELEMENT phase-trio (phase*)>
     <!ELEMENT phase (events*)>

--- a/xslt/html/fcs/character.xsl
+++ b/xslt/html/fcs/character.xsl
@@ -28,6 +28,14 @@
         <xsl:otherwise>false</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
+    <xsl:variable name="wealthStressCount">
+      <xsl:choose>
+        <xsl:when test="hacks/@wealth-stress-count">
+          <xsl:value-of select="hacks/@wealth-stress-count"/>
+        </xsl:when>
+        <xsl:otherwise>0</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <html>
       <xsl:call-template name="head">
         <xsl:with-param name="baseCSS">fcs</xsl:with-param>
@@ -84,6 +92,9 @@
             </xsl:with-param>
             <xsl:with-param name="useSystemsStress">
               <xsl:value-of select="$useSystemsStress"/>
+            </xsl:with-param>
+            <xsl:with-param name="wealthStressCount">
+              <xsl:value-of select="$wealthStressCount"/>
             </xsl:with-param>
           </xsl:call-template>
         </section>

--- a/xslt/html/fcs/stress.xsl
+++ b/xslt/html/fcs/stress.xsl
@@ -6,6 +6,7 @@
     <xsl:param name="useCreditStress"/>
     <xsl:param name="useSkillModes"/>
     <xsl:param name="useSystemsStress"/>
+    <xsl:param name="wealthStressCount"/>
     <xsl:variable name="stressBaseCount">
       <xsl:choose>
         <xsl:when test="/character/hacks/@stress-base-count">
@@ -83,6 +84,14 @@
                   <xsl:with-param name="useSkillModes">
                     <xsl:value-of select="$useSkillModes"/>
                   </xsl:with-param>
+                </xsl:call-template>
+              </xsl:if>
+              <xsl:if test="$wealthStressCount &gt; 0">
+                <xsl:call-template name="generic-stress">
+                  <xsl:with-param name="baseCount">
+                    <xsl:value-of select="$wealthStressCount - 1"/>
+                  </xsl:with-param>
+                  <xsl:with-param name="headerName">Wealth Stress</xsl:with-param>
                 </xsl:call-template>
               </xsl:if>
               <xsl:if test="/character/hacks/@corruption='true'">


### PR DESCRIPTION
Allows https://fate-srd.com/fate-system-toolkit/wealth#wealth-stress

Bug when the number of stress boxes is 1. Seems low-impact.

Closes https://github.com/kbaird/Fate-XSLT/issues/173